### PR TITLE
Downgrade to org.json:json:20180130 fixes synchrony/smsn-mode#29

### DIFF
--- a/brain/build.gradle
+++ b/brain/build.gradle
@@ -6,7 +6,7 @@ dependencies {
   implementation project(':smsn-core')
   implementation project(':smsn-rdf')
 
-  implementation 'org.json:json:20220924'
+  implementation 'org.json:json:20180130'
 
   implementation group: 'org.apache.tinkerpop', name: 'gremlin-core', version: tinkerpopVersion
   implementation group: 'org.apache.tinkerpop', name: 'tinkergraph-gremlin', version: tinkerpopVersion

--- a/smsn-core/build.gradle
+++ b/smsn-core/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
 //  implementation group: 'org.json', name: 'json', version: '20080701'
-//  implementation 'org.json:json:20220924'
+//  implementation 'org.json:json:20230618'
 
   implementation group: 'org.yaml', name: 'snakeyaml', version: '1.15'
 

--- a/smsn-server/build.gradle
+++ b/smsn-server/build.gradle
@@ -19,7 +19,7 @@ dependencies {
   implementation group: 'org.apache.tinkerpop', name: 'gremlin-core', version: tinkerpopVersion
   implementation group: 'org.apache.tinkerpop', name: 'gremlin-server', version: tinkerpopVersion
   implementation group: 'org.eclipse.jgit', name: 'org.eclipse.jgit', version: '4.8.0.201705170830-rc1'
-  implementation 'org.json:json:20220924'
+  implementation 'org.json:json:20180130'
   implementation 'commons-io:commons-io:2.11.0'
 
   implementation(group: 'net.fortytwo.rdfagents', name: 'rdfagents-core', version: rdfagentsVersion) {

--- a/smsn-services/build.gradle
+++ b/smsn-services/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
   implementation project(':smsn-core')
   implementation project(':smsn-rdf')
-  implementation 'org.json:json:20220924'
+  implementation 'org.json:json:20180130'
   implementation group: 'org.openrdf.sesame', name: 'sesame-rio-api', version: sesameVersion
   implementation group: 'net.fortytwo.stream', name: 'stream42-sparql', version: stream42Version
   implementation(group: 'net.fortytwo.rdfagents', name: 'rdfagents-core', version: rdfagentsVersion) {


### PR DESCRIPTION
In order to troubleshoot https://github.com/synchrony/smsn-mode/issues/29 I bisected commits between `smsn` `1.4` to `develop` and narrow down the problem to https://github.com/synchrony/smsn/commit/636ddb17c122da57e845ed2b831e3cdeabdb82db

I further isolated the problem to the `org.json` dependency upgrade to `org.json:json:20220924`. I then bisected the dependency versions and identified that:

- `org.json:json:20180813` has the problem
- `org.json:json:20180130` didn't have the problem

So `20180813` is the version that introduced the bug. The release notes point at this possible culprit https://github.com/stleary/JSON-java/issues/678 

> JSONObject(Map) now throws an exception if any of a map keys are null (#405)

I imagine that some code somewhere (probably in a serializer in the Gremlin Script Engine or SessionOpProcessor or Netty)  is now throwing because of null values in the map (I assume that's what `map keys are null` means), which indeed there are quite a lot of in that payload:
```json
{
  "configuration"=
    {
    "version": "1.5",
    "activityLog": "data/activity.log",
    "transactionBufferSize": 100,
    "thingNamespace": "http://example.org/things/",
    "brainstream": null,
    "verbose": false,
    "services": {
      "agentIri": null,
      "broadcast": {
        "host": "255.255.255.255",
        "port": 42000,
        "graph": null,
        "interval": 5000
      },
      "osc": {
        "host": null,
        "port": 42002,
        "graph": null,
        "interval": 0
      },
      "pubSub": {
        "host": null,
        "port": 42001,
        "graph": null,
        "interval": 0
      },
      "server": null,
      "music": null
    },
    "sources": [
      {
        "name": "private",
        "code": "a",
        "location": "data/sources/private",
        "color": 16711680
      },
      {
        "name": "personal",
        "code": "s",
        "location": "data/sources/personal",
        "color": 16760832
      },
      {
        "name": "public",
        "code": "d",
        "location": "data/sources/public",
        "color": 57344
      },
      {
        "name": "universal",
        "code": "f",
        "location": "data/sources/universal",
        "color": 255
      }
    ]
  },
  "title"="[no title]"
}
```

This downgrade is probably a good enough fix for now since the [future v2 will look quite different](https://github.com/synchrony/smsn/issues?q=is%3Aissue+is%3Aopen+label%3Av2). 