### PR TITLE
Upgrade to gremlin server 3.6.4 / gradle 8

### DIFF
--- a/brain/src/main/java/net/fortytwo/smsn/brain/BrainModeClient.java
+++ b/brain/src/main/java/net/fortytwo/smsn/brain/BrainModeClient.java
@@ -1,7 +1,7 @@
 package net.fortytwo.smsn.brain;
 
 import info.aduna.io.IOUtil;
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/brain/src/test/java/net/fortytwo/smsn/brain/BrainModeClientTest.java
+++ b/brain/src/test/java/net/fortytwo/smsn/brain/BrainModeClientTest.java
@@ -1,6 +1,6 @@
 package net.fortytwo.smsn.brain;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -17,7 +17,7 @@ public class BrainModeClientTest {
 
     private final BrainModeClient.EmacsFunctionExecutor functionExecutor = (function, argument) -> {
         String expr = function.getRequiresArgument()
-                ? "(" + function.getName() + " \"" + StringUtils.escape(argument) + "\")"
+                ? "(" + function.getName() + " \"" + StringEscapeUtils.escapeJava(argument) + "\")"
                 : "(" + function.getName() + ")";
 
         results.add(expr);

--- a/build.gradle
+++ b/build.gradle
@@ -32,10 +32,10 @@ subprojects {
 ext {
   junitVersion = '4.12'
   luceneVersion = '3.6.2'
-  neo4jTinkerpopApiVersion = '0.3-2.3.3'
+  neo4jTinkerpopApiVersion = '0.9-3.4.0'
   rdfagentsVersion = '1.3'
   rippleVersion = '1.5'
   sesameVersion = '4.1.2'
   stream42Version = '1.2'
-  tinkerpopVersion = '3.2.5'
+  tinkerpopVersion = '3.6.4'
 }

--- a/smsn-server/build.gradle
+++ b/smsn-server/build.gradle
@@ -1,13 +1,6 @@
-apply plugin: 'com.github.johnrengelman.shadow'
-apply plugin: 'java'
-
-buildscript {
-  repositories {
-    jcenter()
-  }
-  dependencies {
-    classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.3'
-  }
+plugins {
+  id 'com.github.johnrengelman.shadow' version '8.1.1'
+  id 'java'
 }
 
 dependencies {
@@ -43,5 +36,6 @@ dependencies {
 }
 
 shadowJar {
+  minimize()
   mergeServiceFiles()
 }

--- a/smsn-server/src/main/java/net/fortytwo/smsn/brain/io/yaml/YAMLSource.java
+++ b/smsn-server/src/main/java/net/fortytwo/smsn/brain/io/yaml/YAMLSource.java
@@ -6,6 +6,7 @@ import net.fortytwo.smsn.brain.model.entities.ListNode;
 import net.fortytwo.smsn.brain.model.entities.Note;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.representer.Representer;
 import org.yaml.snakeyaml.resolver.Resolver;
@@ -192,7 +193,9 @@ class YAMLSource {
     private List<Map<String, Object>> loadYaml(final File file) throws IOException {
         try (InputStream in = new FileInputStream(file)) {
             //Yaml yaml = new Yaml();
-            Yaml yaml = new Yaml(new Constructor(), new Representer(), new DumperOptions(), createResolver());
+            LoaderOptions options = new LoaderOptions();
+            Representer representer = new Representer(new DumperOptions());
+            Yaml yaml = new Yaml(new Constructor(options), representer, new DumperOptions(), createResolver());
             return (List<Map<String, Object>>) yaml.load(in);
         }
     }

--- a/smsn-server/src/main/java/net/fortytwo/smsn/gesture/GesturalServer.java
+++ b/smsn-server/src/main/java/net/fortytwo/smsn/gesture/GesturalServer.java
@@ -9,7 +9,7 @@ import net.fortytwo.smsn.p2p.osc.OscSender;
 import net.fortytwo.smsn.p2p.osc.udp.UdpOscSender;
 import net.fortytwo.smsn.rdf.Activities;
 import net.fortytwo.smsn.rdf.vocab.SmSnActivityOntology;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.openrdf.model.IRI;
 import org.openrdf.model.ValueFactory;
 import org.openrdf.model.impl.SimpleValueFactory;
@@ -259,7 +259,7 @@ public class GesturalServer {
         try {
             // TODO: temporary for demo
             Runtime runtime = Runtime.getRuntime();
-            p = runtime.exec("say \"" + StringUtils.escape(message) + "\"");
+            p = runtime.exec("say \"" + StringEscapeUtils.escapeJava(message) + "\"");
         } catch (IOException e) {
             logger.log(Level.WARNING, "'say' command failed", e);
         }

--- a/smsn-server/src/main/java/net/fortytwo/smsn/server/SmSnScriptEngine.java
+++ b/smsn-server/src/main/java/net/fortytwo/smsn/server/SmSnScriptEngine.java
@@ -3,6 +3,7 @@ package net.fortytwo.smsn.server;
 import net.fortytwo.smsn.SemanticSynchrony;
 import net.fortytwo.smsn.server.actions.NoAction;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.tinkerpop.gremlin.jsr223.GremlinScriptEngine;
 import org.apache.tinkerpop.gremlin.jsr223.GremlinScriptEngineFactory;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
@@ -57,6 +58,12 @@ public class SmSnScriptEngine extends AbstractScriptEngine implements GremlinScr
         }
     }
 
+    @Override
+    public Traversal.Admin eval(Bytecode bytecode, Bindings bindings, String traversalSource) {
+        throw new NotImplementedException("use eval(String, ScriptContext) instead");
+    }
+
+
     private Action readAsJson(final String expression) throws IOException {
         return objectMapper.readValue(expression, Action.class);
     }
@@ -85,11 +92,6 @@ public class SmSnScriptEngine extends AbstractScriptEngine implements GremlinScr
 
     private String readerToString(final Reader reader) throws IOException {
         return IOUtils.toString(reader);
-    }
-
-    @Override
-    public Traversal.Admin eval(Bytecode bytecode, Bindings bindings) throws ScriptException {
-        throw new UnsupportedOperationException();
     }
 
     @Override


### PR DESCRIPTION
Key changes are:
 - Upgrade to `gremlin-server` version `3.6.4` and `neo4j-tinkerpop-api-impl` version `0.9-3.4.0`
 - Use of gradle 8 (and corresponding shadowJar plugin)
 - Upgrade `StringUtils.escape` to `StringEscapeUtils.escapeJava` 

Tested with 
 - `M-x smsn` then `M-x smsn-read-vcs` with the public and universal repos, 
 - `C-c s` for a few nodes
 - navigating into nodes in move mode

